### PR TITLE
Optimize conn.kt file

### DIFF
--- a/conn.kt
+++ b/conn.kt
@@ -1,5 +1,4 @@
 import org.springframework.core.ParameterizedTypeReference
-import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
@@ -17,199 +16,180 @@ class Connection(
         }
     }
 
-    private fun <T> Mono<T>.requestSettings(uri: String): Mono<T> = this
-        .timeout(Duration.ofMillis(configuration.requestTimeout))
-        .retryWhen(configuration.retryPolicy)
+    private fun <T> Mono<T>.requestSettings(): Mono<T> =
+        timeout(Duration.ofMillis(configuration.requestTimeout))
+            .retryWhen(configuration.retryPolicy)
 
     inline fun <reified T : Any> performPostRequest(
         uri: String,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPostRequest(uri, body, mapper, object : ParameterizedTypeReference<T>() {})
+        body: Any? = null
+    ): Mono<T> = internalPerformPostRequest(uri, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPostRequestWithVariable(
         uri: String,
         pathVariables: Any? = null,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build(pathVariables) }, body, mapper, object : ParameterizedTypeReference<T>() {})
+        body: Any? = null
+    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build(pathVariables) }, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPostRequestWithVariables(
         uri: String,
         pathVariables: Map<String, Any>,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build(pathVariables) }, body, mapper, object : ParameterizedTypeReference<T>() {})
+        body: Any? = null
+    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build(pathVariables) }, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPostRequestWithParams(
         uri: String,
         queryParams: Map<String, Any?>,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPostRequest({ it.buildURI(uri, queryParams) }, body, mapper, object : ParameterizedTypeReference<T>() {})
+        body: Any? = null
+    ): Mono<T> = internalPerformPostRequest({ it.buildURI(uri, queryParams) }, body, object : ParameterizedTypeReference<T>() {})
 
     fun <T : Any> internalPerformPostRequest(
         uri: String,
         body: Any?,
-        mapper: ((T) -> Any)?,
         responseType: ParameterizedTypeReference<T>
-    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build() }, body, mapper, responseType)
+    ): Mono<T> = internalPerformPostRequest({ it.path(uri).build() }, body, responseType)
 
     fun <T : Any> internalPerformPostRequest(
         uri: (UriBuilder) -> URI,
         body: Any?,
-        mapper: ((T) -> Any)?,
         responseType: ParameterizedTypeReference<T>
     ): Mono<T> {
         return Mono.defer {
-            val request = webClient.post()
+            val spec = webClient.post()
                 .uri(uri)
                 .contentType(configuration.mediaType)
-                .apply { if (body != null) bodyValue(body) }
+
+            val headersSpec = if (body != null) spec.bodyValue(body) else spec
+
+            headersSpec
+                .accept(configuration.mediaType)
                 .retrieve()
                 .bodyToMono(responseType)
-                .requestSettings(uri.toString())
-
-            @Suppress("UNCHECKED_CAST")
-            mapper?.let { request.map(it as (Any?) -> T) } ?: request
+                .requestSettings()
         }
     }
 
     inline fun <reified T : Any> performGetRequest(
-        uri: String,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build() }, mapper, object : ParameterizedTypeReference<T>() {})
+        uri: String
+    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build() }, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performGetRequestWithVariable(
         uri: String,
-        pathVariable: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build(pathVariable) }, mapper, object : ParameterizedTypeReference<T>() {})
+        pathVariable: Any? = null
+    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build(pathVariable) }, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performGetRequestWithVariables(
         uri: String,
-        pathVariables: Map<String, Any>,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build(pathVariables) }, mapper, object : ParameterizedTypeReference<T>() {})
+        pathVariables: Map<String, Any>
+    ): Mono<T> = internalPerformGetRequest({ it.path(uri).build(pathVariables) }, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performGetRequestWithVariableAndParams(
         uri: String,
         pathVariable: Any,
-        queryParams: Map<String, Any?>,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformGetRequest({ it.buildURI(uri, pathVariable, queryParams) }, mapper, object : ParameterizedTypeReference<T>() {})
+        queryParams: Map<String, Any?>
+    ): Mono<T> = internalPerformGetRequest({ it.buildURI(uri, pathVariable, queryParams) }, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performGetRequestWithParams(
         uri: String,
-        queryParams: Map<String, Any?>,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformGetRequest({ it.buildURI(uri, queryParams) }, mapper, object : ParameterizedTypeReference<T>() {})
+        queryParams: Map<String, Any?>
+    ): Mono<T> = internalPerformGetRequest({ it.buildURI(uri, queryParams) }, object : ParameterizedTypeReference<T>() {})
 
     fun <T : Any> internalPerformGetRequest(
         uri: (UriBuilder) -> URI,
-        mapper: ((T) -> Any)? = null,
         responseType: ParameterizedTypeReference<T>
     ): Mono<T> {
         return Mono.defer {
-            val request = webClient.get()
+            webClient.get()
                 .uri(uri)
                 .accept(configuration.mediaType)
                 .retrieve()
                 .bodyToMono(responseType)
-                .requestSettings(uri.toString())
-
-            @Suppress("UNCHECKED_CAST")
-            mapper?.let { request.map(it as (Any?) -> T) } ?: request
+                .requestSettings()
         }
     }
 
     inline fun <reified T : Any> performDeleteRequestWithVariables(
         uri: String,
-        pathVariables: Map<String, Any>,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = performDeleteRequest({ it.path(uri).build(pathVariables) }, mapper, object : ParameterizedTypeReference<T>() {})
+        pathVariables: Map<String, Any>
+    ): Mono<T> = performDeleteRequest({ it.path(uri).build(pathVariables) }, object : ParameterizedTypeReference<T>() {})
 
     fun <T : Any> performDeleteRequest(
         uri: (UriBuilder) -> URI,
-        mapper: ((T) -> Any)? = null,
         responseType: ParameterizedTypeReference<T>
     ): Mono<T> {
         return Mono.defer {
-            val request = webClient.delete()
+            webClient.delete()
                 .uri(uri)
+                .accept(configuration.mediaType)
                 .retrieve()
                 .bodyToMono(responseType)
-                .requestSettings(uri.toString())
-            @Suppress("UNCHECKED_CAST")
-            mapper?.let { request.map(it as (Any?) -> T) } ?: request
+                .requestSettings()
         }
     }
 
     inline fun <reified T : Any> performPatchRequest(
         uri: String,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPatchRequest(uri, body, mapper, object : ParameterizedTypeReference<T>() {}
-    )
+        body: Any? = null
+    ): Mono<T> = internalPerformPatchRequest(uri, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPatchRequestWithVariable(
         uri: String,
         pathVariables: Any? = null,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build(pathVariables) }, body, mapper, object : ParameterizedTypeReference<T>() {}
-    )
+        body: Any? = null
+    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build(pathVariables) }, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPatchRequestWithVariables(
         uri: String,
         pathVariables: Map<String, Any>,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build(pathVariables) }, body, mapper, object : ParameterizedTypeReference<T>() {}
-    )
+        body: Any? = null
+    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build(pathVariables) }, body, object : ParameterizedTypeReference<T>() {})
 
     inline fun <reified T : Any> performPatchRequestWithParams(
         uri: String,
         queryParams: Map<String, Any?>,
-        body: Any? = null,
-        noinline mapper: ((T) -> Any)? = null
-    ): Mono<T> = internalPerformPatchRequest({ it.buildURI(uri, queryParams) }, body, mapper, object : ParameterizedTypeReference<T>() {}
-    )
+        body: Any? = null
+    ): Mono<T> = internalPerformPatchRequest({ it.buildURI(uri, queryParams) }, body, object : ParameterizedTypeReference<T>() {})
 
     fun <T : Any> internalPerformPatchRequest(
         uri: String,
         body: Any?,
-        mapper: ((T) -> Any)?,
         responseType: ParameterizedTypeReference<T>
-    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build() }, body, mapper, responseType
-    )
+    ): Mono<T> = internalPerformPatchRequest({ it.path(uri).build() }, body, responseType)
 
     fun <T : Any> internalPerformPatchRequest(
         uri: (UriBuilder) -> URI,
         body: Any?,
-        mapper: ((T) -> Any)?,
         responseType: ParameterizedTypeReference<T>
     ): Mono<T> {
         return Mono.defer {
-            val request = webClient.patch()
+            val spec = webClient.patch()
                 .uri(uri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .apply { if (body != null) bodyValue(body) }
+                .contentType(configuration.mediaType)
+
+            val headersSpec = if (body != null) spec.bodyValue(body) else spec
+
+            headersSpec
+                .accept(configuration.mediaType)
                 .retrieve()
                 .bodyToMono(responseType)
-                .requestSettings(uri.toString())
-
-            @Suppress("UNCHECKED_CAST")
-            mapper?.let { request.map(it as (Any?) -> T) } ?: request
+                .requestSettings()
         }
     }
 
     fun UriBuilder.buildURI(path: String, queryParams: Map<String, Any?>): URI {
         path(path)
-        queryParams.forEach { (key, value) ->
-            when (value) {
-                is Collection<*> -> queryParam(key, value)
-                else -> queryParam(key, value.toString())
+        queryParams.forEach { (key, raw) ->
+            when (raw) {
+                null -> Unit // skip nulls
+                is Iterable<*> -> {
+                    val values = raw.filterNotNull().map { it as Any }.toTypedArray()
+                    if (values.isNotEmpty()) queryParam(key, *values)
+                }
+                is Array<*> -> {
+                    val values = raw.filterNotNull().map { it as Any }.toTypedArray()
+                    if (values.isNotEmpty()) queryParam(key, *values)
+                }
+                else -> queryParam(key, raw)
             }
         }
         return build()
@@ -217,10 +197,18 @@ class Connection(
 
     fun UriBuilder.buildURI(path: String, pathVariable: Any, queryParams: Map<String, Any?>): URI {
         path(path)
-        queryParams.forEach { (key, value) ->
-            when (value) {
-                is Collection<*> -> queryParam(key, value)
-                else -> queryParam(key, value.toString())
+        queryParams.forEach { (key, raw) ->
+            when (raw) {
+                null -> Unit // skip nulls
+                is Iterable<*> -> {
+                    val values = raw.filterNotNull().map { it as Any }.toTypedArray()
+                    if (values.isNotEmpty()) queryParam(key, *values)
+                }
+                is Array<*> -> {
+                    val values = raw.filterNotNull().map { it as Any }.toTypedArray()
+                    if (values.isNotEmpty()) queryParam(key, *values)
+                }
+                else -> queryParam(key, raw)
             }
         }
         return build(pathVariable)


### PR DESCRIPTION
Refactor `conn.kt` to remove unsafe mappers, standardize media type usage, and enhance URI query parameter building.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7a26b2b-ad88-4e33-9f0e-0122926006d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7a26b2b-ad88-4e33-9f0e-0122926006d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

